### PR TITLE
Fix the situation when some docstrings are not present.

### DIFF
--- a/docs/tutorial.scr
+++ b/docs/tutorial.scr
@@ -122,7 +122,13 @@ will produce links to @cl:spec(call-next-method) and @cl:spec(complex).
 
 Finally, run @c((codex:document :my-system)). You'll see some compilation output
 and a lot of lines with "Inserting documentation for...". When that's done, you
-can open the resulting HTML in your browser.
+can open the resulting HTML in your browser. Codex signals a condition when
+undocumented node (in example, function, class or class slot) is
+encountered. Then you can choose @c(use-docstring) restart and enter a new
+docstring interactively. Also you may wish to silently skip all undocumented
+nodes. This can be achieved by specifing @c(:skip-undocumented t) key to
+@c(codex:document) or setting @c(codex:*skip-undocumented*) variable to T. In
+any case Codex will print summary on undocumented nodes encountered.
 
 @end(section)
 

--- a/src/codex.lisp
+++ b/src/codex.lisp
@@ -13,9 +13,17 @@
                 :output-html-template
                 :output-html-template-options)
   (:export :document
-           :quickstart)
+           :quickstart
+           :*skip-undocumented*)
   (:documentation "The main interface."))
 (in-package :codex)
+
+(defvar *undocumented-list* nil
+  "List of undocumented nodes")
+
+(defvar *skip-undocumented* nil
+  "If this variable is not NIL, do not call a debugger when undocumented node
+is found.")
 
 (defun load-document (document directory)
   "Load a CommonDoc document from the sources of a Codex document."
@@ -81,17 +89,36 @@
                  :message "No such template known."))
       doc)))
 
+(defun undocumented-handler (c)
+  "Handle undocumented nodes"
+  (push (codex.error:node c)
+        *undocumented-list*)
+  (if (and *skip-undocumented*
+           (find-restart 'codex.macro:use-docstring))
+      (invoke-restart 'codex.macro:use-docstring "")))
+
+(defun print-undocumented (undocumented)
+  (flet ((print-node (node)
+           (format t "No docstring for ~a (of type ~a)~%"
+                   (docparser:node-name node)
+                   (type-of node))))
+    (mapc #'print-node undocumented)))
+
 (defun build-manifest (manifest directory)
-  "Build a manifest."
+  "Build a manifest. Return a list of nodes which do not have a docstring."
   ;; First, load all the systems, extracting documentation information into the
   ;; global index
   (let ((codex.macro:*index* (docparser:parse (codex.manifest:manifest-systems manifest)))
-        (*current-markup-format* (codex.manifest:manifest-markup-format manifest)))
+        (*current-markup-format* (codex.manifest:manifest-markup-format manifest))
+        *undocumented-list*)
     ;; Go through each document, building it
     (loop for document in (codex.manifest:manifest-documents manifest) do
-      (build-document document directory))))
+         (handler-bind
+             ((codex.error:no-docstring #'undocumented-handler))
+           (build-document document directory)))
+    *undocumented-list*))
 
-(defun document (system-name)
+(defun document (system-name &key (skip-undocumented *skip-undocumented*))
   "Generate documentation for a system."
   (let ((manifest-pathname (codex.manifest:system-manifest-pathname system-name)))
     (unless (probe-file manifest-pathname)
@@ -99,5 +126,8 @@
              :system-name system-name
              :message "No manifest."))
     (let ((manifest (codex.manifest:parse-manifest manifest-pathname))
-          (directory (uiop:pathname-directory-pathname manifest-pathname)))
-      (build-manifest manifest directory))))
+          (directory (uiop:pathname-directory-pathname manifest-pathname))
+          (*skip-undocumented* skip-undocumented))
+      (print-undocumented
+       (build-manifest manifest directory))))
+  nil)

--- a/src/codex.lisp
+++ b/src/codex.lisp
@@ -119,7 +119,7 @@ is found.")
     *undocumented-list*))
 
 (defun document (system-name &key (skip-undocumented *skip-undocumented*))
-  "Generate documentation for a system."
+  "Generate documentation for a system. @c(skip-undocumented) overrides @c(*skip-undocumented*)"
   (let ((manifest-pathname (codex.manifest:system-manifest-pathname system-name)))
     (unless (probe-file manifest-pathname)
       (error 'codex.error:manifest-error

--- a/src/error.lisp
+++ b/src/error.lisp
@@ -5,12 +5,14 @@
   (:export :codex-error
            :manifest-error
            :unsupported-output-format
-           :template-error)
+           :template-error
+           :no-docstring)
   ;; Accessors
   (:export :system-name
            :message
            :format-name
-           :template-name)
+           :template-name
+           :node)
   (:documentation "Codex errors."))
 (in-package :codex.error)
 
@@ -60,3 +62,15 @@
              (template-name condition)
              (message condition))))
   (:documentation "Signalled by errors related to templates."))
+
+
+(define-condition no-docstring (codex-error)
+  ((node :reader node
+         :initarg :node
+         :documentation "The node without docstring."))
+  (:report
+   (lambda (c s)
+     (let ((node (node c)))
+       (format s "No docstring in node ~a(~a)"
+               node (docparser:node-name node)))))
+  (:documentation "Signalled when a node has no docstring."))


### PR DESCRIPTION
When you `cl-doc`'ing something that as a whole or partially has no documentation string (for example, documented class in which one slot are not documented), codex is very ungracefully falls into debugger. I think this is not fair, maybe this slot has a self-explanatory name or user just does not want to give documentation to it. I provide a solution for that. It's a variable `codex:*skip-undocumented*`. When it is set to `T`, all undocumented nodes are silently ignored. When it is set to opposite, the debugger is invoked on condition `codex.error:no-docstring`. You can choose the docstring interactively there. In any case a summary on undocumented nodes is printed in the end.
