### PR TITLE
codex-test.asd: List CFFI as a dependency

### DIFF
--- a/codex-test.asd
+++ b/codex-test.asd
@@ -4,6 +4,7 @@
   :description "Tests for Codex."
   :depends-on (:codex
                :vertex
+               :cffi
                :common-html
                :fiveam)
   :components ((:module "t"


### PR DESCRIPTION
CFFI is used in [test-system.lisp](https://github.com/CommonDoc/codex/blob/master/t/test-system/test-system.lisp#L61)

Fixes http://report.quicklisp.org/2018-01-16/failure-report/codex.html#codex-test-system

See http://blog.quicklisp.org/2018/01/build-failures-with-asdf-331.html for further context