### PR TITLE
Add documentation types for setf functions, generics, and methods.

### DIFF
--- a/docs/tutorial.scr
+++ b/docs/tutorial.scr
@@ -71,9 +71,12 @@ Belows is the full list of API documentation types:
 
 @begin(list)
 @term(@c(function))
+@term(@c(setf-function))
 @term(@c(macro))
 @term(@c(generic))
+@term(@c(setf-generic))
 @term(@c(method))
+@term(@c(setf-method))
 @term(@c(variable))
 @term(@c(struct))
 @term(@c(class))
@@ -89,6 +92,8 @@ Belows is the full list of API documentation types:
 
 The documentation types prefixed with a 'c' refer to CFFI constructs, i.e.,
 @c(cfunction) refers to a C function declared with CFFI's @c(defcfun) macro.
+The documentation types prefixed with a 'setf-' refer to setf versions
+of their suffix, i.e., @c(setf-function) refers to a setf function.
 
 @end(section)
 


### PR DESCRIPTION
This PL adds being able to include the documentation from setf functions, generics, and methods using new ``@cl:doc()`` variants named ``setf-function``, ``setf-generic``, and ``setf-method``. The function to find the right object (``find_node``) is made to only look at nodes whose setf property (or lack there of) matches with the operator type being looked for, which means that setf functions will be excluded from matching with ``@cl:doc(function ...)`` but will be the only ones looked through for matches with ``@cl:doc(setf-function ...)``.

This should address Issues #13 and #17 .