### PR TITLE
Chanced document function to allow non-default paths to the manifest.

### DIFF
--- a/docs/tutorial.scr
+++ b/docs/tutorial.scr
@@ -6,8 +6,10 @@ This tutorial goes through the process of documenting a Lisp project with Codex.
 @begin(section)
 @title(Getting Started)
 
-First, ceate a folder named @c(docs) in your project's root directory (the same
-directory as the ASDF file). There, you need to create two files:
+First, ceate a folder for your documents. The default is named @c(docs) in
+your project's root directory (the same directory as the ASDF file), but if
+you use another directory, an additional argument will need to be passed to
+@c(codex:document) at the end of this tutorial. There, you need to create two files:
 @c(manifest.lisp) and @c(manual.scr).
 
 The @c(manifest.lisp) file is read by Codex to figure out how to generate your
@@ -120,15 +122,20 @@ will produce links to @cl:spec(call-next-method) and @cl:spec(complex).
 @begin(section)
 @title(Building)
 
-Finally, run @c((codex:document :my-system)). You'll see some compilation output
-and a lot of lines with "Inserting documentation for...". When that's done, you
-can open the resulting HTML in your browser. Codex signals a condition when
-undocumented node (in example, function, class or class slot) is
-encountered. Then you can choose @c(use-docstring) restart and enter a new
-docstring interactively. Also you may wish to silently skip all undocumented
-nodes. This can be achieved by specifing @c(:skip-undocumented t) key to
-@c(codex:document) or setting @c(codex:*skip-undocumented*) variable to T. In
-any case Codex will print summary on undocumented nodes encountered.
+Finally, run @c((codex:document :my-system)); or if you put your documents in
+a non-default directory or named your manifest file something other than
+@c(manifest.lisp), run @c((codex:document :my-system :manifest-path PATH))
+where PATH is the path of the manifest file relative to the the ASDF file
+of @c(:my-system) (e.g. @c(#p"../project-docs/code/code-docs-manifest.lisp")).
+You'll see some compilation output and a lot of lines with
+"Inserting documentation for...". When that's done, you can open the resulting
+HTML in your browser. Codex signals a condition when undocumented node (in
+example, function, class or class slot) is encountered. Then you can choose
+@c(use-docstring) restart and enter a new docstring interactively. Also you
+may wish to silently skip all undocumented nodes. This can be achieved by
+specifing @c(:skip-undocumented t) key to @c(codex:document) or setting
+@c(codex:*skip-undocumented*) variable to T. In any case Codex will print
+summary on undocumented nodes encountered.
 
 @end(section)
 

--- a/src/codex.lisp
+++ b/src/codex.lisp
@@ -118,9 +118,14 @@ is found.")
            (build-document document directory)))
     *undocumented-list*))
 
-(defun document (system-name &key (skip-undocumented *skip-undocumented*))
-  "Generate documentation for a system. @c(skip-undocumented) overrides @c(*skip-undocumented*)"
-  (let ((manifest-pathname (codex.manifest:system-manifest-pathname system-name)))
+(defun document (system-name &key (skip-undocumented *skip-undocumented*)
+                               manifest-path)
+  "Generate documentation for a system. @c(skip-undocumented) overrides @c(*skip-undocumented*)
+@c(manifest-path) overrides @c(*default-manifest-pathname*) which is
+@c(#p\"docs/manifest.lisp\")"
+  (check-type manifest-path (or null pathname))
+  (let ((manifest-pathname (codex.manifest:system-manifest-pathname system-name
+                                                                    :manifest-path manifest-path)))
     (unless (probe-file manifest-pathname)
       (error 'codex.error:manifest-error
              :system-name system-name

--- a/src/manifest.lisp
+++ b/src/manifest.lisp
@@ -140,7 +140,8 @@ package."
   #p"docs/manifest.lisp"
   "The pathname of the Codex manifest in a system.")
 
-(defun system-manifest-pathname (system-name)
-  "Return the absolute pathname to a system's Codex manifest."
+(defun system-manifest-pathname (system-name &key manifest-path)
+  "Return the absolute pathname to a system's Codex manifest. @c(manifest-path)
+overrides @c(*default-manifest-pathname*) which is @c(#p\"docs/manifest.lisp\")"
   (asdf:system-relative-pathname system-name
-                                 *default-manifest-pathname*))
+                                 (if manifest-path manifest-path *default-manifest-pathname*)))


### PR DESCRIPTION
Added the ability to override the default relative path to the manifest ``#p"docs/manifest.lisp"`` by passing a keyword argument ``:manifest-path`` to ``codex:document`` (which then required adding the same for ``codex.manifest:system-manifest-pathname``.

I have a situation where I need to have multiple separate documentation trees, so I needed to add a way to override it.