### PR TITLE
Made class nodes list superclasses.

### DIFF
--- a/templates/static/nodes.css
+++ b/templates/static/nodes.css
@@ -10,7 +10,7 @@
     margin-bottom: 10px;
 }
 
-.codex-lambda-list, .codex-type-def {
+.codex-lambda-list, .codex-superclass-list, .codex-type-def {
     display: inline-block;
     margin-left: 15px;
     margin-top: 0;
@@ -27,6 +27,11 @@
 
 .codex-name {
     font-weight: bold;
+    font-size: 16px;
+}
+
+.codex-superclass-label {
+    font-style: italic;
     font-size: 16px;
 }
 


### PR DESCRIPTION
This makes it so that class documentation nodes list the class' superclasses, including ``t``. Display-wise, it shows up as a line right under the class name that says "Superclasses:" in italics followed by the list of the superclasses (made using list-to-code-node).

There are some potential modifications to this PR that are worth considering.

One is where to actually put the superclass information. This PR puts it on a new line right below the name. Other places could be equally appropriate. One example would be to put the superclasses in a list right after the class name like is seen on quickref.

Another is how the superclasses are displayed. This PR has them put in a list. Another option would be to have them be comma separated like in the ANSI standard documentation.