### PR TITLE
Added table of slot options to class slot nodes

### DIFF
--- a/templates/static/nodes.css
+++ b/templates/static/nodes.css
@@ -35,6 +35,40 @@
     font-size: 16px;
 }
 
+/* Class slot option table styling */
+
+.codex-class-slot-option-node {
+    display: block;
+    margin: 15px;
+    align-items: flex-start;
+    padding: 0px 15px 15px 15px;
+}
+
+.codex-class-slot-option-table {
+    font-weight: normal;
+    font-style: normal;
+    font-size: 16px;
+    text-align: left;
+    margin-left: 15px;
+    padding: 5px 5px 5px 5px;
+}
+
+.codex-class-slot-option-row {
+}
+
+.codex-class-slot-option-label-cell {
+    font-style: italic;
+}
+
+.codex-class-slot-option-value-cell {
+}
+
+.codex-class-slot-option-symbol-cell {
+}
+
+.codex-class-slot-option-list-cell {
+}
+
 /* Documentation node colors */
 
 .codex-function {


### PR DESCRIPTION
This adds a table of the slot options for class slots to their nodes. It is added as a table following the docstring. The left column is the option name and the right column is the value. The left column is in italics and the right column is displayed as code.

The table rows, in order, are

1. Header
2. type
3. initarg, if available
4. initform, if available
5. readers, if available
6. writers, if available
7. accessors, if available

The last rows are only included if the slot has them.

Potential modifications to this PR is where the table would be put, changing it from a table to some other kind of display, changing the order of the rows, and changing the styling.

I am not very experienced with HTML styling, let alone modern HTML5 styling, so the styling might need a lot of work.

I also added a function into ``codex.macro`` named ``write-to-code-node`` which does the exact same thing as ``list-to-code-node`` (which it turns out doesn't actually depend on the passed object being a list) but rather than using ``princ-to-string`` to generate the string it uses ``write-to-string`` with no special keyword arguments given.