### PR TITLE
Added generation of tables of attributes of classes, structs, and str…

### DIFF
--- a/templates/static/nodes.css
+++ b/templates/static/nodes.css
@@ -10,7 +10,7 @@
     margin-bottom: 10px;
 }
 
-.codex-lambda-list, .codex-superclass-list, .codex-type-def {
+.codex-lambda-list, .codex-type-def {
     display: inline-block;
     margin-left: 15px;
     margin-top: 0;
@@ -30,21 +30,17 @@
     font-size: 16px;
 }
 
-.codex-superclass-label {
-    font-style: italic;
-    font-size: 16px;
-}
 
-/* Class slot option table styling */
+/* Class and struct option and slot option table styling */
 
-.codex-class-slot-option-node {
+.codex-class-struct-slot-option-node] {
     display: block;
     margin: 15px;
     align-items: flex-start;
     padding: 0px 15px 15px 15px;
 }
 
-.codex-class-slot-option-table {
+.codex-class-struct-slot-option-table {
     font-weight: normal;
     font-style: normal;
     font-size: 16px;
@@ -53,20 +49,17 @@
     padding: 5px 5px 5px 5px;
 }
 
-.codex-class-slot-option-row {
+.codex-class-struct-slot-option-row {
 }
 
-.codex-class-slot-option-label-cell {
+.codex-class-struct-slot-option-label-cell {
     font-style: italic;
 }
 
-.codex-class-slot-option-value-cell {
+.codex-class-struct-slot-option-value-cell {
 }
 
-.codex-class-slot-option-symbol-cell {
-}
-
-.codex-class-slot-option-list-cell {
+.codex-class-struct-slot-option-symbol-list-cell {
 }
 
 /* Documentation node colors */


### PR DESCRIPTION
…uct slots.


Adds generation of tables of attributes for structs, classes, and struct slots just like https://github.com/CommonDoc/codex/pull/23 added such a table for class slots; now that [eudoxia0/docparser](https://github.com/eudoxia0/docparser) collects these attributes. Note, the PR makes it so that codex will work fine with older versions of docparser as well as the new. It has lots of ```(when (fboundp 'docparser::class-node-metaclass) ...``` like constructs to only use the new features of docparser if available. The ```::``` is necessary in the symbols because otherwise, if using an old docparser version, the code can't compile and load because the symbol isn't exported.

Struct slot attributes are shown in the following order:

1. type
2. read-only
3. accessor
4. initform, if available

Class attributes are shown in the following order:

1. superclasses
2. metaclass, if available
3. default-initargs, if available

And struct attributes are shown, if it is even possible to get them, in the following order:

1. constructor
2. predicate
3. copier
4. print-function, if there is one
5. print-object, if there is one
6. type, if it is something other than nil
7. named, if type is something other than nil
8. initial-offset, if type is something other than nil


You will note that ```:include``` is not yet included. I am not sure what the best way to show that one is. Listing the name of the struct that it inherits from is easy. But I am not sure what the best way to handle the slot overrides is. One possibility would be to convert the slot nodes for the overrides back to a list and then have them one by one on their own line in the cell on the right hand side of the table. Thoughts?

However, there are a few catches, the second of which is a very big one that must be considered.

For classes, the superclass was already listed due to https://github.com/CommonDoc/codex/pull/22. That is now put into the table.

The CSS in [templates/static/nodes.css](https://github.com/CommonDoc/codex/blob/master/templates/static/nodes.css) is a **BIG ONE.** Previously, there were was a CSS entry for the ```codex-superclass-list``` and then lots of CSS entries for the tables but they were class slot specific in that they all have the prefix ```codex-class-slot-option-```. This PR gets renames them to use the ```codex-class-struct-slot``` prefix to make them generic for all attribute tables and got rid of the superclass specific one (now ```codex-class-struct-slot-option-symbol-list-cell``` is used). This does break backwards comparability to some degree, so it must be considered very carefully. One simple way to improve the compatibility would be to keep the old prefixes and just use them for the new tables even though their name isn't completely accurate (the PR can be easily fixed to do this).