### PR TITLE
Fix misuse of FBOUNDP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,8 @@ script:
                     (uiop:quit -1)))'
         -e '(coveralls:with-coveralls (:exclude (list "t" "src/error.lisp"))
               (ql:quickload :codex-templates)
-              (ql:quickload :codex-test))'
-
-notifications:
-  email:
-    - eudoxiahp@gmail.com
+              (ql:quickload :codex-test)
+              (funcall
+               (symbol-function
+                (intern (symbol-name (quote :do-tests))
+                        (find-package :codex-test)))))'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Codex
 
-[![Build Status](https://travis-ci.org/CommonDoc/codex.svg?branch=master)](https://travis-ci.org/CommonDoc/codex)
-[![Coverage Status](https://coveralls.io/repos/CommonDoc/codex/badge.svg?branch=master)](https://coveralls.io/r/CommonDoc/codex?branch=master)
+[![Build Status](https://travis-ci.com/shamazmazum/codex.svg?branch=master)](https://travis-ci.com/shamazmazum/codex)
+[![Coverage Status](https://coveralls.io/repos/github/shamazmazum/codex/badge.svg?branch=master)](https://coveralls.io/github/shamazmazum/codex?branch=master)
 
 A documentation system for Common Lisp.
 

--- a/codex.asd
+++ b/codex.asd
@@ -27,4 +27,8 @@
   :long-description
   #.(uiop:read-file-string
      (uiop:subpathname *load-pathname* "README.md"))
-  :in-order-to ((test-op (test-op codex-test))))
+  :in-order-to ((test-op (load-op codex-test)))
+  :perform (test-op (op system)
+                    (declare (ignore op system))
+                    (format *standard-output*
+                            "You have to run the tests manually with (codex-test:do-tests)")))

--- a/t/codex.lisp
+++ b/t/codex.lisp
@@ -1,7 +1,11 @@
 (in-package :cl-user)
 (defpackage codex-test
-  (:use :cl :fiveam))
+  (:use :cl :fiveam)
+  (:export :do-tests))
 (in-package :codex-test)
+
+(defun do-tests ()
+  (run! 'tests))
 
 ;;; Constants
 
@@ -72,12 +76,7 @@
             (merge-pathnames  #p"doc-a/html/section-a.html"
                               +doc-build-directory+))))
   (is-false
-   (search "No node with name"
-           (uiop:read-file-string
-            (merge-pathnames  #p"doc-b/html/section-a.html"
-                              +doc-build-directory+))))
-  (is-false
-   (search "Unsupported node type"
+   (search "No node type with name"
            (uiop:read-file-string
             (merge-pathnames  #p"doc-b/html/section-a.html"
                               +doc-build-directory+))))
@@ -91,5 +90,3 @@
            (uiop:read-file-string
             (merge-pathnames  #p"doc-b/html/section-b.html"
                               +doc-build-directory+)))))
-
-(run! 'tests)

--- a/t/test-system/test-system.lisp
+++ b/t/test-system/test-system.lisp
@@ -46,7 +46,7 @@
   (declare (ignore tc a))
   t)
 
-(define-condition my-error ()
+(define-condition my-error (simple-condition)
   ((first-slot :accessor first-slot
                :initarg :first-slot
                :documentation "docstring"))

--- a/templates/gamma/style.css
+++ b/templates/gamma/style.css
@@ -76,6 +76,7 @@ a {
 
 .content p code {
     font-size: 16px;
+    background: #f0f0f0;
 }
 
 .content > *, .content blockquote > * {

--- a/templates/gamma/style.css
+++ b/templates/gamma/style.css
@@ -74,7 +74,8 @@ a {
     font-weight: 400;
 }
 
-.content p code {
+.content p code,
+.content li code{
     font-size: 16px;
     background: #f0f0f0;
 }

--- a/templates/static/highlight-lisp/themes/github-readable-comments.css
+++ b/templates/static/highlight-lisp/themes/github-readable-comments.css
@@ -1,0 +1,28 @@
+/**
+ * Inspired by github's default code highlighting
+ */
+pre { white-space: pre; background-color: #f8f8f8; border: 1px solid #ccc; font-size: 13px; line-height: 19px; overflow: auto; padding: 6px 10px; border-radius: 3px; }
+pre code.hl-highlighted {white-space: pre; margin: 0; padding: 0; background: none; border: none; overflow-x: auto; font-size: 13px;}
+code.hl-highlighted {margin: 0 2px; padding: 0 5px; white-space: nowrap; font-family: Consolas, "Liberation Mono", Courier, monospace; background: #f8f8f8; border: 1px solid #eaeaea; border-radius: 3px;}
+
+code.hl-highlighted {color: #008080;}
+code.hl-highlighted .function {color: #008080;}
+code.hl-highlighted .function.known {color: #800603;}
+code.hl-highlighted .function.known.special {color: #2d2d2d; font-weight: bold;}
+code.hl-highlighted .keyword {color: #990073;}
+code.hl-highlighted .keyword.known {color: #990073;}
+code.hl-highlighted .symbol {color: #75a;}
+code.hl-highlighted .lambda-list {color: #966;}
+code.hl-highlighted .number {color: #800;}
+code.hl-highlighted .variable.known {color: #c3c;}
+code.hl-highlighted .variable.global {color: #939;}
+code.hl-highlighted .variable.constant {color: #229;}
+code.hl-highlighted .nil {color: #f00;}
+code.hl-highlighted .list {color: #222;}
+
+code.hl-highlighted .string, code.hl-highlighted .string * {color: #d14 !important;}
+code.hl-highlighted .comment,
+code.hl-highlighted .comment *,
+code.hl-highlighted .comment .string
+code.hl-highlighted .comment .string * {color: #c00000 !important;}
+code.hl-highlighted .string .comment {color: #d14 !important;}

--- a/templates/templates.lisp
+++ b/templates/templates.lisp
@@ -126,7 +126,7 @@
                        #p"style.css")
                  (cons #p"static/highlight-lisp/highlight-lisp.js"
                        #p"highlight.js")
-                 (cons #p"static/highlight-lisp/themes/github.css"
+                 (cons #p"static/highlight-lisp/themes/github-readable-comments.css"
                        #p"highlight.css"))
   :documentation "Minimalist template.")
 
@@ -142,7 +142,7 @@
                        #p"style.css")
                  (cons #p"static/highlight-lisp/highlight-lisp.js"
                        #p"highlight.js")
-                 (cons #p"static/highlight-lisp/themes/github.css"
+                 (cons #p"static/highlight-lisp/themes/github-readable-comments.css"
                        #p"highlight.css"))
   :documentation "Modern template.")
 


### PR DESCRIPTION
Hello.

This patch fixes misuse of `FBOUNDP` which is used to determine if a slot is existing and bound in the object, but only can be used to check if a symbol is bound to a function. The incorrect use makes **codex** unusable. 

Also, there is a possibility that I missed something and there are more places in `src/macro.lisp` where unbound slots can be accessed. But I checked with my libraries which use **codex** for documentation and all works fine. 

And also, It can be good idea to refactor your code and avoid use of `SLOT-EXISTS-P` and `SLOT-BOUNDP` completely using a generic function for collecting rows for the table and specific methods for each node class like so:

~~~~
(defgeneric collect-rows (node)
    (:method-combination append))
(defmethod collect-rows append ((node class-node))
    (list (make-row ...)
           (make-row ...)))
(defmethod collect-rows append ((node struct-node))
    (list (make-row ...)
           (make-row ...)))
;; etc
~~~~